### PR TITLE
added camelCase naming strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ user.getAge(); // work fine and return number
 
 Naming strategies:
 ------
-Supported conversion between different naming cases, such as SnakeCase, KebabCase, PascalCase. Also you can set custom name for property of json object.
+Supported conversion between different naming cases, such as SnakeCase, KebabCase, PascalCase and CamelCase. Also you can set custom name for property of json object.
 
 ```typescript
 const json = {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -14,3 +14,4 @@ export type { INamingStrategy } from "./naming-strategies/INamingStrategy.js";
 export { SnakeCaseNamingStrategy } from "./naming-strategies/SnakeCaseNamingStrategy.js";
 export { PascalCaseNamingStrategy } from "./naming-strategies/PascalCaseNamingStrategy.js";
 export { KebabCaseNamingStrategy } from "./naming-strategies/KebabCaseNamingStrategy.js";
+export { CamelCaseNamingStrategy } from "./naming-strategies/CamelCaseNamingStrategy.js";

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,3 +17,4 @@ export { SerializationSettings } from "./models/SerializationSettings.js";
 export { SnakeCaseNamingStrategy } from "./naming-strategies/SnakeCaseNamingStrategy.js";
 export { PascalCaseNamingStrategy } from "./naming-strategies/PascalCaseNamingStrategy.js";
 export { KebabCaseNamingStrategy } from "./naming-strategies/KebabCaseNamingStrategy.js";
+export { CamelCaseNamingStrategy } from "./naming-strategies/CamelCaseNamingStrategy.js";

--- a/dist/naming-strategies/CamelCaseNamingStrategy.d.ts
+++ b/dist/naming-strategies/CamelCaseNamingStrategy.d.ts
@@ -1,0 +1,5 @@
+import type { INamingStrategy } from "./INamingStrategy.js";
+export declare class CamelCaseNamingStrategy implements INamingStrategy {
+    fromJsonName(name: string): string;
+    toJsonName(name: string): string;
+}

--- a/dist/naming-strategies/CamelCaseNamingStrategy.js
+++ b/dist/naming-strategies/CamelCaseNamingStrategy.js
@@ -1,0 +1,8 @@
+export class CamelCaseNamingStrategy {
+    fromJsonName(name) {
+        return name.slice(0, 1).toUpperCase() + name.slice(1, name.length);
+    }
+    toJsonName(name) {
+        return name.slice(0, 1).toLowerCase() + name.slice(1, name.length);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export type {INamingStrategy} from "./naming-strategies/INamingStrategy.js";
 export {SnakeCaseNamingStrategy} from "./naming-strategies/SnakeCaseNamingStrategy.js";
 export {PascalCaseNamingStrategy} from "./naming-strategies/PascalCaseNamingStrategy.js";
 export {KebabCaseNamingStrategy} from "./naming-strategies/KebabCaseNamingStrategy.js";
+export {CamelCaseNamingStrategy} from "./naming-strategies/CamelCaseNamingStrategy.js";

--- a/src/naming-strategies/CamelCaseNamingStrategy.ts
+++ b/src/naming-strategies/CamelCaseNamingStrategy.ts
@@ -1,0 +1,13 @@
+import type {INamingStrategy} from "./INamingStrategy.js";
+
+export class CamelCaseNamingStrategy implements INamingStrategy {
+
+    public fromJsonName (name: string): string {
+        return name.slice(0, 1).toUpperCase() + name.slice(1, name.length);
+    }
+
+    public toJsonName (name: string): string {
+        return name.slice(0, 1).toLowerCase() + name.slice(1, name.length);
+    }
+
+}


### PR DESCRIPTION
При работе с данными апи, где поля называются в PascalCase, а проект на React, где PascalCase используется в основном для названия компонентов, приходиться как-то поменять названии полей 👎 

В этом вопросе `namingStrategy` очень вручает 👍, но если сервер в POST/PUT запросах, также ожидает данные, где поля называются в PascalCase, то не хватает `CamelCaseNamingStrategy`, поэтому я ее добавил и прошу принять PR.

Пример:
EmployeeModel.ts
```ts
@jsonObject({ namingStrategy: new PascalCaseNamingStrategy() })
export class EmployeeModel extends Serializable {
  @jsonProperty(Number, null) employeeId: number | null = null;
  @jsonProperty(String, null) lastName: string | null = null;
  @jsonProperty(String, null) firstName: string | null = null;
  @jsonProperty(String, null) email: string | null = null;
}
```
```json
{
  "EmployeeId": 1,
  "LastName": "Иван",
  "FirstName": "Иванов",
  "Email": "ivan123@test.ru",
}
```
```ts
const employee = new EmployeeModel().fromJSON(json);
```

EmployeeDto.ts - для создания/обновление данных сотрудника.
```ts
@jsonObject({ namingStrategy: new CamelCaseNamingStrategy() })
export class EmployeeDto extends Serializable {
  @jsonProperty(String, null) LastName: string | null = null;
  @jsonProperty(String, null) FirstName: string | null = null;
  @jsonProperty(String, null) Email: string | null = null;
}
```
```ts
const formValues = {
  lastName: "Иван",
  firstName: "Иванов",
  email: "ivanIvanov@example.com"
}

const dto = new EmployeeDto().fromJSON(formValues);
```

**Спасибо за отличный инструмент 🤝**